### PR TITLE
Fixed ataruFormUrl implementation

### DIFF
--- a/koulutustarjonta-common/src/main/java/fi/helsinki/koulutustarjonta/domain/ApplicationOption.java
+++ b/koulutustarjonta-common/src/main/java/fi/helsinki/koulutustarjonta/domain/ApplicationOption.java
@@ -32,5 +32,4 @@ public class ApplicationOption {
     private String aoFormUrl;
     private String asFormUrl;
     private boolean asSystemApplicationForm;
-    private boolean AtaruTypeFormUrl;
 }

--- a/koulutustarjonta-service/src/main/java/fi/helsinki/koulutustarjonta/mapping/ApplicationOptionModelMapper.java
+++ b/koulutustarjonta-service/src/main/java/fi/helsinki/koulutustarjonta/mapping/ApplicationOptionModelMapper.java
@@ -4,15 +4,19 @@ import fi.helsinki.koulutustarjonta.domain.ApplicationOption;
 import fi.helsinki.koulutustarjonta.domain.Requirement;
 import fi.helsinki.koulutustarjonta.dto.ApplicationOptionDTO;
 import fi.helsinki.koulutustarjonta.dto.I18NDTO;
+import javafx.application.Application;
 import org.modelmapper.AbstractConverter;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.PropertyMap;
 import org.modelmapper.convention.MatchingStrategies;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Hannu Lyytikainen
  */
 public class ApplicationOptionModelMapper extends ModelMapper {
+    static final Logger LOG = LoggerFactory.getLogger(ApplicationOptionModelMapper.class);
     public ApplicationOptionModelMapper(String apiEndpoint) {
         super();
         this.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
@@ -59,7 +63,7 @@ public class ApplicationOptionModelMapper extends ModelMapper {
         @Override
         protected I18NDTO convert(ApplicationOption source) {
             boolean systemApplicationForm = source.isAsSystemApplicationForm();
-            if(source.isAtaruTypeFormUrl()){
+            if(source.getAoFormUrl() != null && source.getAoFormUrl().equals("ataruFormUrl")){
                 return ataruTypeUrl(source.getOid());
             } else if (!systemApplicationForm && source.getAsFormUrl() != null) {
                 return hakuperusteetUrl(source.getOid());

--- a/koulutustarjonta-update/src/main/java/fi/helsinki/koulutustarjonta/client/converter/ApplicationOptionConverter.java
+++ b/koulutustarjonta-update/src/main/java/fi/helsinki/koulutustarjonta/client/converter/ApplicationOptionConverter.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import fi.helsinki.koulutustarjonta.client.KoodistoClient;
 import fi.helsinki.koulutustarjonta.domain.ApplicationOption;
 import fi.helsinki.koulutustarjonta.domain.Requirement;
+import org.apache.log4j.Logger;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,6 +17,7 @@ public class ApplicationOptionConverter extends BaseConverter {
 
     private final ExamConverter examConverter;
     private final AttachmentConverter attachmentConverter;
+    static final Logger LOG = Logger.getLogger(ApplicationOptionConverter.class);
 
     public ApplicationOptionConverter(KoodistoClient koodistoClient) {
         super(koodistoClient);
@@ -56,11 +58,14 @@ public class ApplicationOptionConverter extends BaseConverter {
             ao.setFirstTimePositions(content.get("ensikertalaistenAloituspaikat").intValue());
         }
 
+        // This string is checked for in class ApplicationOptionModelMapper. And if AoFormUrl equals 'ataruFormUrl',
+        // then a correct URL is set, otherwise another kind of URL is set. This kind of a workaround is used, because
+        // for some reason, the URL is not saved in the database and is only defined after a query to the API is made.
+        // It would probably make more sense to save the correct URL in the database, but the process of defining it was
+        // using several different classes and refactoring the logic to be included here might have introduced some errors.
+        // As a result, I implemented this quick workaround, because the planned lifetime of this application is near its end.
         if (content.has("ataruLomakeAvain")) {
-            ao.setAtaruTypeFormUrl(true);
-        }
-        else {
-            ao.setAtaruTypeFormUrl(false);
+            ao.setAoFormUrl("ataruFormUrl");
         }
 
         return ao;


### PR DESCRIPTION
For some reason, application option form url is not saved into database even though there is a field for that. I used that field to convey information if the form in question is a atary type form so that a correct form url can be defined later when the API is queried. 